### PR TITLE
🎨 Palette: expose the active asset state programmatically to screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,6 @@
+
+## 2024-05-18 - Exposing Active Element States Programmatically
+
+**Learning:** When elements act as toggles within a group (like the asset selector tabs `GC`, `ES`, `NQ`), visual indications (like an `.active` CSS class) are insufficient for screen readers. The active state must be programmatically communicated.
+
+**Action:** Add `role="group"` and an appropriate `aria-label` to the container. Apply `aria-pressed="true"` to the currently active toggle and `aria-pressed="false"` to inactive toggles. Ensure any JavaScript responsible for toggling visual classes (e.g., `switchAsset` in `app.js`) is also updated to keep the `aria-pressed` states synchronized.

--- a/docs/app.js
+++ b/docs/app.js
@@ -581,7 +581,10 @@ function switchAsset(asset) {
 
   // Update button states
   document.querySelectorAll('.asset-btn').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.asset === asset);
+    const isActive = btn.dataset.asset === asset;
+    btn.classList.toggle('active', isActive);
+    // Keep the programmatic pressed state synchronized with the visible active tab.
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 
   // Update asset label

--- a/docs/index.html
+++ b/docs/index.html
@@ -31,14 +31,14 @@
 
       <div class="controls-bar">
         <!-- Asset Selector -->
-        <div class="asset-selector" id="asset-selector">
-          <button class="asset-btn active" data-asset="GC" id="btn-gc" onclick="switchAsset('GC')">
+        <div class="asset-selector" id="asset-selector" role="group" aria-label="Asset Selection">
+          <button class="asset-btn active" data-asset="GC" id="btn-gc" onclick="switchAsset('GC')" aria-pressed="true">
             GC <span class="kbd-hint">1</span>
           </button>
-          <button class="asset-btn" data-asset="ES" id="btn-es" onclick="switchAsset('ES')">
+          <button class="asset-btn" data-asset="ES" id="btn-es" onclick="switchAsset('ES')" aria-pressed="false">
             ES <span class="kbd-hint">2</span>
           </button>
-          <button class="asset-btn" data-asset="NQ" id="btn-nq" onclick="switchAsset('NQ')">
+          <button class="asset-btn" data-asset="NQ" id="btn-nq" onclick="switchAsset('NQ')" aria-pressed="false">
             NQ <span class="kbd-hint">3</span>
           </button>
         </div>


### PR DESCRIPTION
## 💡 What

Added `role="group"` and `aria-label="Asset Selection"` to the `.asset-selector` container.
Added `aria-pressed="true"`/`"false"` states to the asset selector buttons (`GC`, `ES`, `NQ`) and synchronized them programmatically in `app.js`.

## 🎯 Why

The asset selector buttons act as a group of toggles. Previously, the active asset was only communicated visually via the `.active` CSS class. This change ensures screen-reader users can programmatically determine which asset is currently active and understand that these buttons function as a group.

Affected users:
- Screen-reader users

## 🔎 Before

- The asset buttons only used the `.active` CSS class.
- The `.asset-selector` had no group semantics.

## ✨ After

- The asset selector container has `role="group"` and `aria-label="Asset Selection"`.
- The asset buttons use `aria-pressed="true"` or `aria-pressed="false"`.
- `switchAsset` keeps `aria-pressed` in sync with the `.active` class.

## ♿ Accessibility

- **Accessible name:** Container now has `aria-label="Asset Selection"`.
- **Role:** Container now has `role="group"`.
- **Pressed state:** Asset buttons use `aria-pressed`.

## ✅ Verification

- `git diff --check`
- `node --check docs/app.js`

## 🛡️ Scope

- The change is under 50 production lines.
- No dependencies were added.
- No package-manager files were added.
- No Python analytics were changed.
- No chart calculations were changed.
- No JSON schemas were changed.
- No generated data was committed.
- Existing visual styling was preserved.

---
*PR created automatically by Jules for task [4137041598473052187](https://jules.google.com/task/4137041598473052187) started by @Hewkaw02*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved screen reader support for the asset selector.
  * Asset buttons now clearly communicate their active or inactive state.
  * Added a descriptive label for the selector group.
  * Button accessibility states stay synchronized when switching assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->