### PR TITLE
🎨 Palette: add accessible timeframe tab states

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -2480,7 +2480,10 @@ function switchChartTab(group, tabKey) {
   const tabGroup = document.getElementById(`${group}-tabs`);
   if (tabGroup) {
     tabGroup.querySelectorAll('.chart-tab').forEach(btn => {
-      btn.classList.toggle('active', btn.dataset.tab === tabKey);
+      const isActive = btn.dataset.tab === tabKey;
+      btn.classList.toggle('active', isActive);
+      // Keep the programmatic pressed state synchronized with the visible active tab.
+      btn.setAttribute('aria-pressed', String(isActive));
     });
   }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -113,11 +113,11 @@
               <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-session" checked onchange="toggleLayer('hybrid', 'sessionLevels')"> Session Levels</label>
               <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-oiwalls" checked onchange="toggleLayer('hybrid', 'oiWalls')"> OI Walls</label>
             </div>
-            <div class="chart-tab-group" id="hybrid-tabs">
-              <button class="chart-tab" data-tab="hybrid_1d" onclick="switchChartTab('hybrid', 'hybrid_1d')">1D</button>
-              <button class="chart-tab" data-tab="hybrid_1h" onclick="switchChartTab('hybrid', 'hybrid_1h')">1H</button>
+            <div class="chart-tab-group" id="hybrid-tabs" role="group" aria-label="Hybrid Chart Timeframe Selection">
+              <button class="chart-tab" data-tab="hybrid_1d" onclick="switchChartTab('hybrid', 'hybrid_1d')" aria-pressed="false">1D</button>
+              <button class="chart-tab" data-tab="hybrid_1h" onclick="switchChartTab('hybrid', 'hybrid_1h')" aria-pressed="false">1H</button>
               <button class="chart-tab active" data-tab="hybrid_15m"
-                onclick="switchChartTab('hybrid', 'hybrid_15m')">15M</button>
+                onclick="switchChartTab('hybrid', 'hybrid_15m')" aria-pressed="true">15M</button>
             </div>
           </div>
         </div>
@@ -135,11 +135,11 @@
               <label class="layer-toggle"><input type="checkbox" id="toggle-master-setup" checked onchange="toggleLayer('master', 'tradeSetup')"> Trade Setup</label>
               <label class="layer-toggle"><input type="checkbox" id="toggle-master-walls" checked onchange="toggleLayer('master', 'oiWalls')"> Option Walls</label>
             </div>
-            <div class="chart-tab-group" id="intraday-master-tabs">
+            <div class="chart-tab-group" id="intraday-master-tabs" role="group" aria-label="Intraday Master Chart Timeframe Selection">
               <button class="chart-tab active" data-tab="intraday_master_5m"
-                onclick="switchChartTab('intraday-master', 'intraday_master_5m')">5M</button>
+                onclick="switchChartTab('intraday-master', 'intraday_master_5m')" aria-pressed="true">5M</button>
               <button class="chart-tab" data-tab="intraday_master_1h"
-                onclick="switchChartTab('intraday-master', 'intraday_master_1h')">1H</button>
+                onclick="switchChartTab('intraday-master', 'intraday_master_1h')" aria-pressed="false">1H</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 💡 What 
 
Added `role="group"`, an `aria-label`, and synced `aria-pressed` state to the chart timeframe selectors (`1D`, `1H`, `15M`, `5M`, `1H`).
 
## 🎯 Why 
 
Visual tab groups (like `.active` classes) do not communicate their active state programmatically to screen readers. This makes it impossible for visually impaired users to know which timeframe is currently selected when using keyboard navigation.
 
## 🔎 Before 
 
The chart timeframe buttons used a visual `.active` class for the selected state and lacked container group semantics. Screen-readers would simply read them as unpressed, unaffiliated buttons.
 
## ✨ After 
 
The containers now have `role="group"` and an `aria-label`. The timeframe buttons programmatically expose their active status through `aria-pressed`, which is synchronized in `docs/app.js` when the visible active state is toggled.
 
## ♿ Accessibility 
 
- Added `role="group"` to the parent containers.
- Added descriptive `aria-label`s to the parent containers.
- Implemented synced `aria-pressed="true"`/`false"` on the buttons.
 
## ✅ Verification 
 
- `git diff --check` 
- `node --check docs/app.js` 
- Local static-server smoke test 
- Keyboard-only navigation 
- Code review complete and local artifacts (e.g. `server_output.log`) cleaned up.
 
## 🛡️ Scope 
 
- The change is under approximately 50 production lines 
- No dependencies were added 
- No package-manager files were added 
- No Python analytics were changed 
- No chart calculations were changed 
- No JSON schemas were changed 
- No generated data was committed 
- Existing visual styling was preserved

---
*PR created automatically by Jules for task [1604042717086890441](https://jules.google.com/task/1604042717086890441) started by @Hewkaw02*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved chart tab controls with clearer group labels for assistive technologies.
  * Synchronized each tab’s pressed state with the currently selected tab.
  * Added accessible state indicators for active and inactive chart tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->