### PR TITLE
⚡ Bolt: eliminate repeated strike scans in max-pain calculation

### DIFF
--- a/update_dashboard.py
+++ b/update_dashboard.py
@@ -288,23 +288,28 @@ def parse_option_data_csv(csv_path):
     # Max Pain Calculation
     max_pain_result = None
     if active_strikes and (any(call_oi.get(s, 0) > 0 for s in active_strikes) or any(put_oi.get(s, 0) > 0 for s in active_strikes)):
-        min_pain = float('inf')
-        best_strike = active_strikes[len(active_strikes) // 2]
+        # Calculate initial pain at the lowest strike
+        # At the lowest strike, no calls are ITM, and all puts for strikes > lowest strike are ITM.
+        current_pain = sum(put_oi.get(s, 0) * (s - active_strikes[0]) for s in active_strikes)
+        min_pain = current_pain
+        best_strike = active_strikes[0]
         
-        for settle_price in active_strikes:
-            total_pain = 0
-            for s in active_strikes:
-                # Call pain: if settle > strike, calls are ITM
-                if settle_price > s:
-                    total_pain += call_oi.get(s, 0) * (settle_price - s)
-                # Put pain: if settle < strike, puts are ITM  
-                if settle_price < s:
-                    total_pain += put_oi.get(s, 0) * (s - settle_price)
-            
-            if total_pain < min_pain:
-                min_pain = total_pain
-                best_strike = settle_price
+        cum_call_oi = call_oi.get(active_strikes[0], 0)
+        current_put_oi = sum(put_oi.get(s, 0) for s in active_strikes) - put_oi.get(active_strikes[0], 0)
         
+        # Iterate through remaining strikes to calculate total pain using an O(N) single pass
+        for i in range(1, len(active_strikes)):
+            diff = active_strikes[i] - active_strikes[i-1]
+            slope = cum_call_oi - current_put_oi
+            current_pain += slope * diff
+
+            if current_pain < min_pain:
+                min_pain = current_pain
+                best_strike = active_strikes[i]
+
+            cum_call_oi += call_oi.get(active_strikes[i], 0)
+            current_put_oi -= put_oi.get(active_strikes[i], 0)
+
         max_pain_result = {
             "price": best_strike,
             "total_pain": round(min_pain, 0),


### PR DESCRIPTION
## 💡 What

Replaced the $O(N^2)$ algorithm for calculating max pain in `update_dashboard.py` with an $O(N)$ linear scan algorithm that calculates total pain by iterating through the strikes and updating the current pain based on a precalculated slope (`cum_call_oi - current_put_oi`).

## 🎯 Why

The previous implementation used a nested loop that iterated through all strikes to sum up the pain for each `settle_price` (which itself iterated over all strikes). By recognizing that moving from one strike to the next changes the pain in a predictable way (a linear slope based on the running sums of Call and Put OI), we can perform the calculation in a single pass. This is a real bottleneck when there are many strikes (e.g. hundreds or thousands in deep chains).

## 📊 Impact

- Before: 1.8222s
- After: 0.0402s
- Improvement: 97.8% runtime reduction 
- Input: 200 strikes (3000 to 5000), dummy randomized Call and Put Open Interests (0-1000).
- Runs: 100 iterations of the max-pain loop block.

## 🔬 Measurement

Benchmark command used:

```python
import time
import random

active_strikes = sorted([float(i) for i in range(3000, 5000, 10)])
call_oi = {s: random.randint(0, 1000) for s in active_strikes}
put_oi = {s: random.randint(0, 1000) for s in active_strikes}

# Optimized implementation using linear scan
start = time.perf_counter()
for _ in range(100):
    # O(N) calculation code ...
optimized_time = time.perf_counter() - start
print(f"Optimized implementation time: {optimized_time:.4f}s")
```

The benchmark isolated the core computational loop, generating dummy integer data to avoid external network dependencies.

## ✅ Verification

- Python compilation: `python -m compileall -q analytics Trading_Core Analysis_Tools update_dashboard.py run_all.py` (Passed)
- Existing test suite: N/A (no formal test suite)
- Targeted regression test: Used a simple script checking the exact final `best_strike` and `min_pain` numbers generated from randomized Call/Put data over the same range, finding exact equality.
- Benchmark: Confirmed 97% execution time reduction on random strike distributions.
- Frontend syntax or smoke test: N/A

## 🛡️ Safety

- Financial formulas are unchanged. The $O(N)$ calculation calculates the *exact same values* as the sum.
- CSV and JSON schemas are unchanged.
- No dependencies were added.
- No credentials or generated artifacts were committed.
- Existing behavior is preserved (including tie-breaking, which still favors the lower strike).


---
*PR created automatically by Jules for task [2505411403855068945](https://jules.google.com/task/2505411403855068945) started by @Hewkaw02*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved max-pain calculation efficiency while maintaining the same results.
  * Faster processing across strike intervals for dashboard data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->