### PR TITLE
🎨 Palette: add accessible keyboard shortcut semantics to navigation controls

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -10,3 +10,9 @@
 **Learning:** The dashboard utilizes continuous, infinite CSS animations (`pulse-dot`, `blink`, `pulse-glow`) for various status indicators and loaders. These can cause distraction or discomfort for users with motion sensitivities.
 
 **Action:** Always append a `@media (prefers-reduced-motion: reduce)` block to the end of stylesheets. Within this block, disable animations (`animation: none !important;`) and transitions (`transition: none !important;`) for animated indicators and interactive elements to ensure the UI respects accessibility preferences.
+
+## 2025-01-20 - Exposing Keyboard Shortcuts Programmatically
+
+**Learning:** When interactive controls contain visible keyboard shortcuts (like `GC <span class="kbd-hint">1</span>`), screen readers will read the shortcut text as part of the element's accessible name (e.g. "GC 1"), causing confusion.
+
+**Action:** Add `aria-hidden="true"` to the element containing the visible shortcut to hide it from assistive technology. Expose the shortcut programmatically by adding the `aria-keyshortcuts` attribute (e.g., `aria-keyshortcuts="1"`) to the parent interactive element (like the `<button>`).

--- a/docs/index.html
+++ b/docs/index.html
@@ -32,25 +32,25 @@
       <div class="controls-bar">
         <!-- Asset Selector -->
         <div class="asset-selector" id="asset-selector" role="group" aria-label="Asset Selection">
-          <button class="asset-btn active" data-asset="GC" id="btn-gc" onclick="switchAsset('GC')" aria-pressed="true">
-            GC <span class="kbd-hint">1</span>
+          <button class="asset-btn active" data-asset="GC" id="btn-gc" onclick="switchAsset('GC')" aria-pressed="true" aria-keyshortcuts="1">
+            GC <span class="kbd-hint" aria-hidden="true">1</span>
           </button>
-          <button class="asset-btn" data-asset="ES" id="btn-es" onclick="switchAsset('ES')" aria-pressed="false">
-            ES <span class="kbd-hint">2</span>
+          <button class="asset-btn" data-asset="ES" id="btn-es" onclick="switchAsset('ES')" aria-pressed="false" aria-keyshortcuts="2">
+            ES <span class="kbd-hint" aria-hidden="true">2</span>
           </button>
-          <button class="asset-btn" data-asset="NQ" id="btn-nq" onclick="switchAsset('NQ')" aria-pressed="false">
-            NQ <span class="kbd-hint">3</span>
+          <button class="asset-btn" data-asset="NQ" id="btn-nq" onclick="switchAsset('NQ')" aria-pressed="false" aria-keyshortcuts="3">
+            NQ <span class="kbd-hint" aria-hidden="true">3</span>
           </button>
         </div>
 
         <!-- Time Navigator -->
         <div class="time-nav" id="time-nav">
-          <button class="time-btn" id="btn-prev" onclick="navigateTime(-1)" title="Older (← Arrow)" aria-label="Previous Data">◀</button>
+          <button class="time-btn" id="btn-prev" onclick="navigateTime(-1)" title="Older (← Arrow)" aria-label="Previous Data" aria-keyshortcuts="ArrowLeft">◀</button>
           <div class="time-display" id="time-display">
             <span id="time-label">Loading...</span>
             <span class="time-index" id="time-index"></span>
           </div>
-          <button class="time-btn" id="btn-next" onclick="navigateTime(1)" title="Newer (→ Arrow)" aria-label="Next Data">▶</button>
+          <button class="time-btn" id="btn-next" onclick="navigateTime(1)" title="Newer (→ Arrow)" aria-label="Next Data" aria-keyshortcuts="ArrowRight">▶</button>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## 💡 What

Adds accessible keyboard shortcut semantics to the navigation controls by applying `aria-keyshortcuts` to the buttons and hiding the visual keyboard hints (`<span class="kbd-hint">`) from screen readers with `aria-hidden="true"`.

## 🎯 Why

Previously, screen readers would read the visible shortcut hint as part of the button's accessible name (e.g., reading "GC 1" instead of just "GC"), causing confusion. This improvement solves the issue by correctly separating the accessible name from the keyboard shortcut metadata. It benefits screen-reader users by cleaning up the button label, while still exposing the shortcut programmatically.

## 🔎 Before

The visual hint `<span class="kbd-hint">1</span>` inside the `<button>` for the `GC` asset caused the button's accessible name to be calculated as "GC 1". Similar issues existed for other asset buttons and navigation buttons did not announce their shortcuts.

## ✨ After

The `<span class="kbd-hint">1</span>` is now hidden from assistive technologies (`aria-hidden="true"`). The parent `<button>` correctly surfaces the shortcut using `aria-keyshortcuts="1"`. Time navigation buttons also surface their `ArrowLeft` and `ArrowRight` shortcuts.

## ♿ Accessibility

- Accessible Name: Remains pristine (e.g., "GC" instead of "GC 1")
- Keyboard Interaction: Explicitly communicated via `aria-keyshortcuts`.
- Visual styling and presentation remain entirely unaffected.

## ✅ Verification

- `git diff --check`
- Local static-server smoke test
- Keyboard-only navigation
- 375px responsive check

*Node.js syntax checks were omitted as no JS was modified. Screen reader tests were conceptualized against standard ARIA implementation rules but manual AT testing was not executed.*

## 🛡️ Scope

- The change is under approximately 50 production lines
- No dependencies were added
- No package-manager files were added
- No Python analytics were changed
- No chart calculations were changed
- No JSON schemas were changed
- No generated data was committed
- Existing visual styling was preserved

---
*PR created automatically by Jules for task [5347875046332955620](https://jules.google.com/task/5347875046332955620) started by @Hewkaw02*