### PR TITLE
🎨 Palette: connect layer control checkboxes to the charts they modify

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -16,3 +16,9 @@
 **Learning:** When interactive controls contain visible keyboard shortcuts (like `GC <span class="kbd-hint">1</span>`), screen readers will read the shortcut text as part of the element's accessible name (e.g. "GC 1"), causing confusion.
 
 **Action:** Add `aria-hidden="true"` to the element containing the visible shortcut to hide it from assistive technology. Expose the shortcut programmatically by adding the `aria-keyshortcuts` attribute (e.g., `aria-keyshortcuts="1"`) to the parent interactive element (like the `<button>`).
+
+## 2025-02-18 - Connecting Controls to Charts
+
+**Learning:** When checkboxes or controls toggle visual layers on a specific chart, the relationship is not inherently obvious to screen reader users, especially when multiple charts exist.
+
+**Action:** Wrap layer control panels in a `role="group"` with an appropriate `aria-label` (e.g., `aria-label="Hybrid Chart Layers"`). Add the `aria-controls` attribute to each checkbox `input` referencing the `id` of the chart container it modifies (e.g., `aria-controls="chart-hybrid"`).

--- a/docs/index.html
+++ b/docs/index.html
@@ -108,10 +108,10 @@
         <div class="card-header">
           <span class="card-title">Hybrid Candle &amp; OI S/R Zones</span>
           <div class="header-controls-group">
-            <div class="layer-control-panel">
-              <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-sdbands" checked onchange="toggleLayer('hybrid', 'sdBands')"> SD Bands</label>
-              <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-session" checked onchange="toggleLayer('hybrid', 'sessionLevels')"> Session Levels</label>
-              <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-oiwalls" checked onchange="toggleLayer('hybrid', 'oiWalls')"> OI Walls</label>
+            <div class="layer-control-panel" role="group" aria-label="Hybrid Chart Layers">
+              <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-sdbands" checked onchange="toggleLayer('hybrid', 'sdBands')" aria-controls="chart-hybrid"> SD Bands</label>
+              <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-session" checked onchange="toggleLayer('hybrid', 'sessionLevels')" aria-controls="chart-hybrid"> Session Levels</label>
+              <label class="layer-toggle"><input type="checkbox" id="toggle-hybrid-oiwalls" checked onchange="toggleLayer('hybrid', 'oiWalls')" aria-controls="chart-hybrid"> OI Walls</label>
             </div>
             <div class="chart-tab-group" id="hybrid-tabs" role="group" aria-label="Hybrid Chart Timeframe Selection">
               <button class="chart-tab" data-tab="hybrid_1d" onclick="switchChartTab('hybrid', 'hybrid_1d')" aria-pressed="false">1D</button>
@@ -130,10 +130,10 @@
         <div class="card-header">
           <span class="card-title">Intraday Master Chart (Decision Terminal)</span>
           <div class="header-controls-group">
-            <div class="layer-control-panel">
-              <label class="layer-toggle"><input type="checkbox" id="toggle-master-vwap" checked onchange="toggleLayer('master', 'vwap')"> VWAP</label>
-              <label class="layer-toggle"><input type="checkbox" id="toggle-master-setup" checked onchange="toggleLayer('master', 'tradeSetup')"> Trade Setup</label>
-              <label class="layer-toggle"><input type="checkbox" id="toggle-master-walls" checked onchange="toggleLayer('master', 'oiWalls')"> Option Walls</label>
+            <div class="layer-control-panel" role="group" aria-label="Intraday Master Chart Layers">
+              <label class="layer-toggle"><input type="checkbox" id="toggle-master-vwap" checked onchange="toggleLayer('master', 'vwap')" aria-controls="chart-intraday-master"> VWAP</label>
+              <label class="layer-toggle"><input type="checkbox" id="toggle-master-setup" checked onchange="toggleLayer('master', 'tradeSetup')" aria-controls="chart-intraday-master"> Trade Setup</label>
+              <label class="layer-toggle"><input type="checkbox" id="toggle-master-walls" checked onchange="toggleLayer('master', 'oiWalls')" aria-controls="chart-intraday-master"> Option Walls</label>
             </div>
             <div class="chart-tab-group" id="intraday-master-tabs" role="group" aria-label="Intraday Master Chart Timeframe Selection">
               <button class="chart-tab active" data-tab="intraday_master_5m"


### PR DESCRIPTION
## 💡 What

Add missing semantic groupings (`role="group"`) to chart layer control panels and explicit control relationships (`aria-controls`) to the individual checkboxes, linking them directly to the Hybrid and Intraday Master chart containers they modify.

## 🎯 Why

When screen reader users interact with toggle checkboxes that control visual layers on a specific chart, it is difficult to determine which part of the interface will be updated upon interaction—especially when multiple charts exist. This change provides programmatic context, allowing assistive technology users to understand the relationship between the control and the resulting visual update, removing ambiguity for those who cannot see the immediate visual change on the chart.

## 🔎 Before

The `layer-control-panel` containers lacked semantic grouping, appearing as arbitrary collections of checkboxes. The individual `input type="checkbox"` elements toggled chart layers visually, but had no programmatic link to the `div` containers displaying the Hybrid or Intraday Master charts. 

## ✨ After

The layer control panels are now exposed as a logical group with an accessible label (e.g. `aria-label="Hybrid Chart Layers"`). Every layer checkbox now carries the `aria-controls` attribute targeting its specific chart ID (`chart-hybrid` or `chart-intraday-master`). 

## ♿ Accessibility

- `role="group"` established on the container groups the checkboxes logically.
- `aria-label` provides a concise name for the group.
- `aria-controls` explicitly establishes the relationship between the trigger (the checkbox) and the target region (the chart).
- Focus states and keyboard operability remain fully preserved. 

## ✅ Verification

- `git diff --check`
- Local static-server smoke test (`python -m http.server 8000 --directory docs`)
- Executed Playwright script to verify accessibility interactions
- Visual check: captured video and screenshot ensuring no layout shifts or regressions were introduced.

## 🛡️ Scope

- The change is under approximately 50 production lines.
- No dependencies were added.
- No package-manager files were added.
- No Python analytics were changed.
- No chart calculations were changed.
- No JSON schemas were changed.
- No generated data was committed.
- Existing visual styling was completely preserved.

---
*PR created automatically by Jules for task [288654671490891746](https://jules.google.com/task/288654671490891746) started by @Hewkaw02*