### PR TITLE
🎨 Palette: announce the active asset to screen readers

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -583,7 +583,9 @@ function switchAsset(asset) {
 
   // Update button states
   document.querySelectorAll('.asset-btn').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.asset === asset);
+    const isActive = btn.dataset.asset === asset;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', String(isActive));
   });
 
   // Update asset label

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,14 +34,14 @@
 
       <div class="controls-bar">
         <!-- Asset Selector -->
-        <div class="asset-selector" id="asset-selector">
-          <button class="asset-btn active" data-asset="GC" id="btn-gc" onclick="switchAsset('GC')">
+        <div class="asset-selector" id="asset-selector" role="group" aria-label="Asset Selection">
+          <button class="asset-btn active" data-asset="GC" id="btn-gc" onclick="switchAsset('GC')" aria-pressed="true">
             GC <span class="kbd-hint">1</span>
           </button>
-          <button class="asset-btn" data-asset="ES" id="btn-es" onclick="switchAsset('ES')">
+          <button class="asset-btn" data-asset="ES" id="btn-es" onclick="switchAsset('ES')" aria-pressed="false">
             ES <span class="kbd-hint">2</span>
           </button>
-          <button class="asset-btn" data-asset="NQ" id="btn-nq" onclick="switchAsset('NQ')">
+          <button class="asset-btn" data-asset="NQ" id="btn-nq" onclick="switchAsset('NQ')" aria-pressed="false">
             NQ <span class="kbd-hint">3</span>
           </button>
         </div>


### PR DESCRIPTION
## 💡 What

Adds programmatic `aria-pressed` states to the main asset selector buttons (`GC`, `ES`, `NQ`) and groups them semantically using `role="group"`.

## 🎯 Why

Currently, the active state of the selected asset is only indicated visually via an `.active` CSS class. Screen-reader users cannot determine which asset is currently selected when navigating the buttons.

This change benefits:
- Screen-reader users

## 🔎 Before

The asset buttons were visually styled, but had no semantic selected state:
```html
<div class="asset-selector" id="asset-selector">
  <button class="asset-btn active" data-asset="GC" ...>
```

## ✨ After

The container is now semantically grouped, and buttons expose their pressed state:
```html
<div class="asset-selector" id="asset-selector" role="group" aria-label="Asset Selection">
  <button class="asset-btn active" data-asset="GC" aria-pressed="true" ...>
```

## ♿ Accessibility

- **Role:** Grouped the asset buttons logically using `role="group"`.
- **Accessible Name:** Provided `aria-label="Asset Selection"` to the container.
- **Pressed State:** Added `aria-pressed` to the buttons. The active button is marked `aria-pressed="true"` and the inactive buttons are marked `aria-pressed="false"`. This state is synchronized in JavaScript.

## ✅ Verification

- `node --check docs/app.js` (Syntax passed)
- Local static-server smoke test (`python -m http.server`)
- Playwright script confirmation of `aria-pressed` toggling logic and visual screenshot check.
- `git diff --check`

## 🛡️ Scope

- The change is under 50 production lines.
- No dependencies were added.
- No package-manager files were added.
- No Python analytics were changed.
- No chart calculations were changed.
- No JSON schemas were changed.
- No generated data was committed.
- Existing visual styling was preserved.

---
*PR created automatically by Jules for task [5200770797913203728](https://jules.google.com/task/5200770797913203728) started by @Hewkaw02*